### PR TITLE
all: add full implementation of instrumented Client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# ocredispy
-OpenCensus wrapper for redis-py

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,48 @@
+ocredis
+======
+
+Redis-Py wrapper that provides observability using OpenCensus for
+distributed tracing and metrics.
+
+
+Tests
+-----
+Tests can be run by using `pytest`, for example
+```shell
+pytest
+```
+
+
+Metrics available
+-----------------
+
+- calls
+- latency
+- key_length
+- value_length
+
+.. csv-table::
+    :header: "Metric", "View Name", "Unit", "Tags"
+    :widths: 20, 20, 20, 20
+
+    "Latency", "redispy/latency", "ms", "'error', 'method', 'status'"
+    "Calls", "redispy/calls", "1", "'error', 'method', 'status'"
+    "Key lengths", "redispy/key_length", "By", "'error', 'method', 'status'"
+    "Value lengths", "redispy/value_length", "By", "'error', 'method', 'status'"
+
+
+Installing it
+-------------
+
+pip install ocredis
+
+
+Using it
+--------
+
+You can initialize exactly how you would for redis.Redis. In fact it is meant to be a drop replacement with just:
+
+- Changing the import statement from "import redis" to "import ocredis"
+- Changing the client initialization from "client = redis.Redis(host=host, port=port)" to "client = ocredis.OcRedis(host=host, port=port)"
+
+and the rest is trivial to use then.

--- a/ocredis/__init__.py
+++ b/ocredis/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from ocredis.client import OcRedis
+    from ocredis.observability import register_views
+except ImportError:
+    from .ocredis.client import OcRedis
+    from .ocredis.observability import register_views
+except Exception as e:
+    raise e
+
+__all__ = [
+        'OcRedis',
+        'register_views'
+        ]

--- a/ocredis/client.py
+++ b/ocredis/client.py
@@ -1,0 +1,1080 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import redis
+
+try:
+    from ocredis.observability import trace_and_record_stats_with_key_and_value
+except ImportError:
+    from .ocredis.observability import trace_and_record_stats_with_key_and_value
+except Exception as e:
+    raise e
+
+class OcRedis(redis.Redis):
+    """
+    OcRedis is the instrumented wrapper for redis.Redis clients.
+    It provides distributed traces and metrics using OpenCensus.
+    """
+
+    def append(self, key, value, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.append',
+                super(OcRedis, self).append, key, value, *args, **kwargs)
+
+    def bgrewriteaof(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.bgrewriteaof',
+                super(OcRedis, self).bgrewriteaofget, None, None)
+
+    def bgsave(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.bgsave',
+                super(OcRedis, self).bgsave, None, None)
+
+    def bitcount(self, key, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.bgsave',
+                super(OcRedis, self).bgsave, key, *args, **kwargs)
+
+    def bitfield(self, key, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.bitfield',
+                super(OcRedis, self).bitfield, key, *args, **kwargs)
+
+    def bitop(self, operation, dest, *keys):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.bitop',
+                super(OcRedis, self).bitop, None, None, operation, dest, *keys)
+
+    def blpop(self, keys, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.blpop',
+                super(OcRedis, self).blpop, keys, None, keys, *args, **kwargs)
+
+    def brpop(self, keys, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.brpop',
+                super(OcRedis, self).brpop, keys, None, keys, *args, **kwargs)
+
+    def brpoplpush(self, src, dst, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.brpoplpush',
+                super(OcRedis, self).brpoplpush, None, None, src, ds, *args, **kwargs)
+
+    def bzpopmax(self, keys, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.bzpopmax',
+                super(OcRedis, self).bzpopmax, keys, None, keys, *args, **kwargs)
+
+    def bzpopmin(self, keys, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.bzpopmin',
+                super(OcRedis, self).bzpopmin, keys, None, keys, *args, **kwargs)
+
+    def client_getname(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.client_getname',
+                super(OcRedis, self).client_getname, None, None)
+
+    def client_id(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.client_id',
+                super(OcRedis, self).client_id, None, None)
+
+    def client_kill(self, address):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.client_kill',
+                super(OcRedis, self).client_kill, None, None, address)
+
+    def client_kill_filter(self, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.client_kill_filter',
+                super(OcRedis, self).client_kill_filter, None, None, *args, **kwargs)
+
+    def client_list(self, _type=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.client_list',
+                super(OcRedis, self).client_list, None, None, _type)
+
+    def client_pause(self, timeout):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.client_pause',
+                super(OcRedis, self).client_pause, None, None, timeout)
+
+    def client_setname(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.client_setname',
+                super(OcRedis, self).client_setname, None, None, name)
+
+    def cluster(self, cluster_arg, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.cluster',
+                super(OcRedis, self).cluster, None, None, cluster_arg, *args)
+
+    def config_get(self, *args, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.config_get',
+                super(OcRedis, self).config_get, None, None, *args, **kwargs)
+
+    def config_resetstat(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.config_resetstat',
+                super(OcRedis, self).config_resetstats, None, None)
+
+    def config_rewrite(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.config_rewrite',
+                super(OcRedis, self).config_rewrite, None, None)
+
+    def config_set(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.config_set',
+                super(OcRedis, self).config_set, name, value)
+
+    def dbsize(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.dbsize',
+                super(OcRedis, self).dbsize, None, None)
+
+    def dbsize(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.dbsize',
+                super(OcRedis, self).dbsize, None, None)
+
+    def debug_object(self, key):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.debug_object',
+                super(OcRedis, self).debug_object, key, None)
+
+    def decr(self, name, amount=1):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.decr',
+                super(OcRedis, self).decr, name, None, name, amount)
+
+    def decrby(self, name, amount=1):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.decrby',
+                super(OcRedis, self).decrby, name, None, name, amount)
+
+    def delete(self, *names):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.delete',
+                super(OcRedis, self).delete, None, None, *names)
+
+    def dump(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.dump',
+                super(OcRedis, self).dump, name, None)
+
+    def echo(self, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.echo',
+                super(OcRedis, self).echo, value, None)
+
+    def eval(self, script, numkeys, *keys_and_args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.eval',
+                super(OcRedis, self).eval, None, None, script, numkeys, *keys_and_args)
+
+    def execute_command(self, *args, **options):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.execute_command',
+                super(OcRedis, self).execute_command, None, None, *args, **options)
+
+    def evalsha(self, sha, numkeys, *keys_and_args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.evalsha',
+                super(OcRedis, self).evalsha, None, None, sha, numkeys, *keys_and_args)
+
+    def exists(self, *names):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.exxists',
+                super(OcRedis, self).exists, None, None, *names)
+
+    def expire(self, name, time):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.expire',
+                super(OcRedis, self).expire,name, None, name, time)
+
+    def flushall(self, asynchronous=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.flushall',
+                super(OcRedis, self).flushall, None, None, asynchronous)
+
+    def geoadd(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.geoadd',
+                super(OcRedis, self).geoadd, name, None, name, *values)
+
+    def geodist(self, name, place1, place2, unit=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.geodist',
+                super(OcRedis, self).geodist, name, None, name, place1, place2, unit)
+
+    def geohash(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.geohash',
+                super(OcRedis, self).geohash, name, None, name, *values)
+
+    def geopos(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.geopos',
+                super(OcRedis, self).geopos, name, None, name, *values)
+
+    def georadius(self, name, longitude, latitude, radius, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.georadius',
+                super(OcRedis, self).georadius, name, None, name, longitude, latitude, **kwargs)
+
+    def georadiusbymember(self, name, member, radius, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.georadiusbymember',
+                super(OcRedis, self).georadiusbymember, name, None, name, member, raidus, **kwargs)
+
+    def get(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.get',
+                super(OcRedis, self).get, name, None, name)
+
+    def getbit(self, name, offset):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.getbit',
+                super(OcRedis, self).getbit, name, None, name, offset)
+
+    def getrange(self, key, start, end):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.getrange',
+                super(OcRedis, self).getrange, key, None, key, start, end)
+
+    def getset(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.getset',
+                super(OcRedis, self).getset, name, None, name, value)
+
+    def hdel(self, name, *keys):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hdel',
+                super(OcRedis, self).hdel, name, None, name, *keys)
+
+    def hexists(self, name, key):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hexists',
+                super(OcRedis, self).hexists, name, key, name, key)
+
+    def hget(self, name, key):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hget',
+                super(OcRedis, self).hget, name, key, name, key)
+
+    def hgetall(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hgetall',
+                super(OcRedis, self).hgetall, name, None, name)
+
+    def hincrby(self, name, key, amount=1):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hincrby',
+                super(OcRedis, self).hincrby, name, key, name, key, amount)
+
+    def hincrbyfloat(self, name, key, amount=1.0):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hincrbyfloat',
+                super(OcRedis, self).hincrbyfloat, name, key, name, key, amount)
+
+    def hkeys(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hkeys',
+                super(OcRedis, self).hkeys, name, None, name)
+
+    def hlen(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hlen',
+                super(OcRedis, self).hlen, name, None, name)
+
+    def hmget(self, name, key, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hmget',
+                super(OcRedis, self).hmget, name, key, name, key, *args)
+
+    def hmset(self, name, mapping):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hmset',
+                super(OcRedis, self).hmset, name, None, name, mapping)
+
+    def hscan(self, name, cursor=0, match=None, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hscan',
+                super(OcRedis, self).hscan, name, None, name, cursor, match, count)
+
+    def hscan_iter(self, name, match=None, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hscan_iter',
+                super(OcRedis, self).hscan_iter, name, None, name, match, count)
+
+    def hset(self, name, key, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hset',
+                super(OcRedis, self).hset, key, value, name, key, value)
+
+    def hsetnx(self, name, key, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hsetnx',
+                super(OcRedis, self).hsetnx, key, value, name, key, value)
+
+    def hstrlen(self, name, key):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hstrlen',
+                super(OcRedis, self).hstrlen, name, key, name, key)
+
+    def hvals(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.hvals',
+                super(OcRedis, self).hvals, name, None, name)
+
+    def incr(self, name, amount=1):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.incr',
+                super(OcRedis, self).incr, name, None, name, amount)
+
+    def incrby(self, name, amount=1):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.incrby',
+                super(OcRedis, self).incrby, name, None, name, amount)
+
+    def incrbyfloat(self, name, amount=1.0):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.incrbyfloat',
+                super(OcRedis, self).incrbyfloat, name, None, name, amount)
+
+    def info(self, section=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.info',
+                super(OcRedis, self).info, None, None, section)
+
+    def keys(self, pattern=u'*'):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.keys',
+                super(OcRedis, self).keys, pattern, None, pattern)
+
+    def lastsave(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lastsave',
+                super(OcRedis, self).lastsave, None, None)
+
+    def lindex(self, name, index):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lindex',
+                super(OcRedis, self).lindex, name, None, name, index)
+
+    def linsert(self, name, where, refvalue, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.linsert',
+                super(OcRedis, self).linsert, name, None, name, where, refvalue, value)
+
+    def llen(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.llen',
+                super(OcRedis, self).llen, name, None, name)
+
+    def lock(self, name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lock',
+                super(OcRedis, self).lock, name, None, name, timeout, sleep, blocking_timeout, thread_local)
+
+    def lpop(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lpop',
+                super(OcRedis, self).lpop, name, None, name)
+
+    def lpush(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lpush',
+                super(OcRedis, self).lpop, name, values, name, values)
+
+    def lpushx(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lpushx',
+                super(OcRedis, self).lpushx, name, value, name, value)
+
+    def lrange(self, name, start, end):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lrange',
+                super(OcRedis, self).lrange, name, None, name, start, end)
+
+    def lrem(self, name, start, end):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lrem',
+                super(OcRedis, self).lrem, name, None, name, start, end)
+
+    def lset(self, name, index, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.lset',
+                super(OcRedis, self).lset, name, None, name, index, value)
+
+    def ltrim(self, name, start, end):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.ltrim',
+                super(OcRedis, self).ltrim, name, None, name, start, end)
+
+    def memory_purge(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.memory_purge',
+                super(OcRedis, self).memory_purge, None, None)
+
+    def memory_usage(self, key, samples=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.memory_usage',
+                super(OcRedis, self).memory_usage, key, None, key, samples)
+
+    def mget(self, keys, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.mget',
+                super(OcRedis, self).mget, keys, None, keys, *args)
+
+    def migrate(self, host, port, keys, destination_db, timeout, copy=False, replace=False, auth=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.migrate',
+                super(OcRedis, self).migrate, keys, None, host, port, keys, destination_db, timeout, copy, replace, auth)
+
+    def move(self, name, db):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.move',
+                super(OcRedis, self).move, name, None, name, db)
+
+    def mset(self, mapping):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.mset',
+                super(OcRedis, self).mset, None, None, mapping)
+
+    def msetnx(self, mapping):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.msetnx',
+                super(OcRedis, self).msetnx, None, None, mapping)
+
+    def object(self, infotype, key):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.object',
+                super(OcRedis, self).object, key, None, infotype, key)
+
+    def parse_response(self, connection, command_name, **options):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.parse_response',
+                super(OcRedis, self).parse_response, None, None, connection, command_name, **options)
+
+    def persist(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.persist',
+                super(OcRedis, self).persist, name, None, name)
+
+    def pexpire(self, name, time):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pexpire',
+                super(OcRedis, self).pexpire, name, None, name, time)
+
+    def pfadd(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pfadd',
+                super(OcRedis, self).pfadd, name, None, name, *values)
+
+    def ping(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.ping',
+                super(OcRedis, self).ping, None, None)
+
+    def pipeline(self, transaction=True, shard_hint=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pipeline',
+                super(OcRedis, self).pipeline, None, None, transaction, shard_hint)
+
+    def psetex(self, name, time_ms, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.psetex',
+                super(OcRedis, self).psetex, name, None, name, time_ms, value)
+
+    def pttl(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pttl',
+                super(OcRedis, self).pttl, name, None)
+
+    def publish(self, channel, message):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.publish',
+                super(OcRedis, self).publish, channel, message, channel, message)
+
+    def pubsub(self, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pubsub',
+                super(OcRedis, self).pubsub, None, None, **kwargs)
+
+    def pubsub_channels(self, pattern=u'*'):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pubsub_channels',
+                super(OcRedis, self).pubbsub_channels, pattern, None, pattern)
+
+    def pubsub_numpat(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pubsub_numpat',
+                super(OcRedis, self).pubsub_numpat, None, None)
+
+    def pubsub_numsub(self, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.pubsub_numsub',
+                super(OcRedis, self).pubsub_numsub, None, None, *args)
+
+    def randomkey(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.randomkey',
+                super(OcRedis, self).randomkey, None, None)
+
+    def register_script(self, script):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.register_script',
+                super(OcRedis, self).register_script, script, None, script)
+
+    def rename(self, src, dst):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.rename',
+                super(OcRedis, self).rename, src, dst, src, dst)
+
+    def renamenx(self, src, dst):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.renamenx',
+                super(OcRedis, self).renamenx, src, dst, src, dst)
+
+    def restore(self, name, ttl, value, replace=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.restore',
+                super(OcRedis, self).restore, name, value, name, ttl, value, replace)
+
+    def rpop(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.rpop',
+                super(OcRedis, self).rpop, name, None, name)
+
+    def rpoplpush(self, src, dst):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.rpoplpush',
+                super(OcRedis, self).rpop, src, dst, src, dst)
+
+    def rpush(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.rpush',
+                super(OcRedis, self).rpush, name, None, name)
+
+    def rpushx(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.rpushx',
+                super(OcRedis, self).rpush, name, value, name, value)
+
+    def sadd(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sadd',
+                super(OcRedis, self).sadd, name, values, name, *values)
+
+    def save(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.save',
+                super(OcRedis, self).save, None, None)
+
+    def scan(self, cursor=0, match=None, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.scan',
+                super(OcRedis, self).scan, None, None, cursor, match, count)
+
+    def scan_iter(self, match=None, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.scan_iter',
+                super(OcRedis, self).scan_iter, None, None, match, count)
+
+    def scard(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.scard',
+                super(OcRedis, self).scard, name, None, name)
+
+    def script_exists(self, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.script_exists',
+                super(OcRedis, self).script_exists, args, None, *args)
+
+    def script_flush(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.script_flush',
+                super(OcRedis, self).script_flush, None, None)
+
+    def script_kill(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.script_kill',
+                super(OcRedis, self).script_kill, None, None)
+
+    def script_load(self, script):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.script_load',
+                super(OcRedis, self).script_load, script, None, script)
+
+    def sdiff(self, keys, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sdiff',
+                super(OcRedis, self).sdiff, keys, None, keys, *args)
+
+    def sdiffstore(self, dest, keys, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sdiffstore',
+                super(OcRedis, self).sdiffstore, keys, None, dest, keys, *args)
+
+    def sentinel(self, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel',
+                super(OcRedis, self).sentinel, None, None, *args)
+
+    def sentinel_get_master_addr_by_name(self, service_name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_get_master_addr_by_name',
+                super(OcRedis, self).sentinel_get_master_addr_by_name, service_name, None, service_name)
+
+    def sentinel_master(self, service_name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_master',
+                super(OcRedis, self).sentinel_master, service_name, None, service_name)
+
+    def sentinel_masters(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_masters',
+                super(OcRedis, self).sentinel_masters, None, None)
+
+    def sentinel_monitor(self, name, ip, port, quorum):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_monitor',
+                super(OcRedis, self).sentinel_monitor, name, None, name, ip, port, quorum)
+
+    def sentinel_remove(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_remove',
+                super(OcRedis, self).sentinel_remove, name, None, name)
+
+    def sentinel_sentinels(self, service_name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_sentinels',
+                super(OcRedis, self).sentinel_sentinels, service_name, None, service_name)
+
+    def sentinel_set(self, name, option, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_set',
+                super(OcRedis, self).sentinel_set, name, value, name, option, value)
+
+    def sentinel_slaves(self, service_name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sentinel_slaves',
+                super(OcRedis, self).sentinel_slaves, service_name, None, service_name)
+
+    def set(self, name, value, ex=None, px=None, nx=False, xx=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.set',
+                super(OcRedis, self).set, name, None, name, value, ex, px, nx, xx)
+
+    def set_response_callback(self, command, callback):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.set_response_callback',
+                super(OcRedis, self).set_response_callback, command, None, command, callback)
+
+    def setbit(self, name, offset, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.setbit',
+                super(OcRedis, self).setbit, name, value, name, offset, value)
+
+    def setex(self, name, time, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.setex',
+                super(OcRedis, self).setex, name, value, name, time, value)
+
+    def setnx(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.setnx',
+                super(OcRedis, self).setnx, name, value, name, value)
+
+    def setrange(self, name, offset, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.setrange',
+                super(OcRedis, self).setrange, name, value, name, offset, value)
+
+    def shutdown(self, save=False, nosave=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.shutdown',
+                super(OcRedis, self).shutdown, None, None, save, nosave)
+
+    def sinter(self, keys, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sinter',
+                super(OcRedis, self).sinter, keys, None, keys, *args)
+
+    def sinterstore(self, dest, keys, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sinterstore',
+                super(OcRedis, self).sinterstore, keys, dest, dest, keys, *args)
+
+    def sismember(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sismember',
+                super(OcRedis, self).sismember, name, value, name, value)
+
+    def slaveof(self, host=None, port=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.slaveof',
+                super(OcRedis, self).slaveof, host, port, host, port)
+
+    def slowlog_get(self, num=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.slowlog_get',
+                super(OcRedis, self).slowlog_get, None, None, num)
+
+    def slowlog_len(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.slowlog_len',
+                super(OcRedis, self).slowlog_len, None, None)
+
+    def slowlog_reset(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.slowlog_reset',
+                super(OcRedis, self).slowlog_reset, None, None)
+
+    def smembers(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.smembers',
+                super(OcRedis, self).smembers, name, None, name)
+
+    def smove(self, src, dst, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.smove',
+                super(OcRedis, self).smove, src, value, src, dst, value)
+
+    def sort(self, name, start=None, num=None, by=None, get=None, desc=False, alpha=False, store=None, groups=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sort',
+                super(OcRedis, self).sort, name, None, name, start, num, by, get, desc, alpha, store, groups)
+
+    def spop(self, name, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.spop',
+                super(OcRedis, self).spop, name, None, name, count)
+
+    def srandmember(self, name, number=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.srandmember',
+                super(OcRedis, self).srandmember, name, None, name, number)
+
+    def srem(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.srem',
+                super(OcRedis, self).srem, name, None, name, *values)
+
+    def sscan(self, name, cursor=0, match=None, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sscan',
+                super(OcRedis, self).sscan, name, None, name, cursor, match, count)
+
+    def sscan_iter(self, name, match=None, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sscan_iter',
+                super(OcRedis, self).sscan_iter, name, None, name, match, count)
+
+    def strlen(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.strlen',
+                super(OcRedis, self).strlen, name, None, name)
+
+    def substr(self, name, start, end=-1):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.substr',
+                super(OcRedis, self).substr, name, None, name, start, end)
+
+    def sunion(self, keys, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sunion',
+                super(OcRedis, self).sunion, keys, None, keys, *args)
+
+    def sunionstore(self, dest, keys, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.sunionstore',
+                super(OcRedis, self).sunionstore, dest, keys, dest, keys, *args)
+
+    def swapdb(self, first, second):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.swapdb',
+                super(OcRedis, self).swapdb, first, second, first, second)
+
+    def time(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.time',
+                super(OcRedis, self).swapdb, None, None)
+
+    def touch(self, *args):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.touch',
+                super(OcRedis, self).touch, None, None, *args)
+
+    def transaction(self, func, *watches, **kwargs):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.transaction',
+                super(OcRedis, self).transaction, None, None, *watches, **kwargs)
+
+    def ttl(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.ttl',
+                super(OcRedis, self).ttl, name, None, name)
+
+    def type(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.type',
+                super(OcRedis, self).type, name, None, name)
+
+    def unlink(self, *names):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.unlink',
+                super(OcRedis, self).unlink, names, None, names)
+
+    def unwatch(self):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.unwatch',
+                super(OcRedis, self).unwatch, None, None)
+
+    def wait(self, num_replicas, timeout):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.wait',
+                super(OcRedis, self).wait, None, None, num_replicas, timeout)
+
+    def watch(self, *names):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.watch',
+                super(OcRedis, self).watch, names, None, *names)
+
+    def xack(self, name, groupname, *ids):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xack',
+                super(OcRedis, self).xack, name, groupname, name, groupname, *ids)
+
+    def xadd(self, name, fields, id=u'*', maxlen=None, approximate=True):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xadd',
+                super(OcRedis, self).xadd, name, fields, name, fields, id, maxlen, approximate)
+
+    def xclaim(self, name, groupname, consumername, min_idle_time, message_ids, idle=None, time=None,
+                    retryCount=None, force=False, justid=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xclaim',
+                super(OcRedis, self).xclaim, name, groupname, consumername, min_idle_time, message_ids,
+                idle, time, retryCount, force, justid)
+
+    def xdel(self, name, *ids):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xdel',
+                super(OcRedis, self).xdel, name, None, name, *ids)
+
+    def xdel(self, name, *ids):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xdel',
+                super(OcRedis, self).xdel, name, None, name, *ids)
+
+    def xgroup_create(self, name, groupname, id=u'$', mkstream=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xgroup_create',
+                super(OcRedis, self).xgroup_create, name, groupname, name, groupname, id, mkstream)
+
+    def xgroup_delconsumer(self, name, groupname, consumername):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xgroup_delconsumer',
+                super(OcRedis, self).xgroup_delconsumer, name, groupname, name, groupname, consumername)
+
+    def xgroup_destroy(self, name, groupname):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xgroup_destroy',
+                super(OcRedis, self).xgroup_destroy, name, groupname, name, groupname)
+
+    def xgroup_setid(self, name, groupname, id):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xgroup_setid',
+                super(OcRedis, self).xgroup_setid, name, groupname, name, groupname, id)
+
+    def xinfo_consumers(self, name, groupname):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xgroup_consumers',
+                super(OcRedis, self).xgroup_consumers, name, groupname, name, groupname)
+
+    def xinfo_groups(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xinfo_groups',
+                super(OcRedis, self).xinfo_groups, name, None, name)
+
+    def xinfo_stream(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xinfo_stream',
+                super(OcRedis, self).xinfo_stream, name, None, name)
+
+    def xlen(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xlen',
+                super(OcRedis, self).xlen, name, None, name)
+
+    def xpending(self, name, groupname):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xpending',
+                super(OcRedis, self).xpending, name, groupname, name, groupname)
+
+    def xpending_range(self, name, groupname, min, max, count, consumername=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xpending_range',
+                super(OcRedis, self).xpending_range, name, groupname, name, groupname, min, max, count, consumername)
+
+    def xrange(self, name, min=u'-', max=u'+', count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xrange',
+                super(OcRedis, self).xrange, name, None, name, min, max, count)
+
+    def xread(self, streams, count=None, block=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xread',
+                super(OcRedis, self).xread, None, None, streams, count, block)
+
+    def xreadgroup(self, groupname, consumername, streams, count=None, block=None, noack=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xreadgroup',
+                super(OcRedis, self).xreadgroup, groupname, consumername, groupname, consumername, streams, count, block, noack)
+
+    def xrevrange(self, name, max=u'+', min=u'-', count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xrevrange',
+                super(OcRedis, self).xrevrange, name, None, name, max, min, count)
+
+    def xtrim(self, name, maxlen, approximate=True):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.xtrim',
+                super(OcRedis, self).xtrim, name, None, name, maxlen, approximate)
+
+    def zadd(self, name, mapping, nx=False, xx=False, ch=False, incr=False):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zadd',
+                super(OcRedis, self).zadd, name, None, name, mapping, nx, xx, ch, incr)
+
+    def zcard(self, name):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zcard',
+                super(OcRedis, self).zcard, name, None, name)
+
+    def zcount(self, name, min, max):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zcount',
+                super(OcRedis, self).zcount, name, None, name, min, max)
+
+    def zincrby(self, name, amount, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zincrby',
+                super(OcRedis, self).zincrby, name, None, name, amount, value)
+
+    def zinterstore(self, dest, keys, aggregate=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zinterstore',
+                super(OcRedis, self).zinterstore, dest, keys, dest, keys, aggregate)
+
+    def zlexcount(self, name, min, max):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zlexcount',
+                super(OcRedis, self).zlexcount, name, None, name, min, max)
+
+    def zpopmax(self, name, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zpopmax',
+                super(OcRedis, self).zpopmax, name, None, name, count)
+
+    def zpopmin(self, name, count=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zpopmin',
+                super(OcRedis, self).zpopmin, name, None, name, count)
+
+    def zrange(self, name, start, end, desc=False, withscores=False, score_cast_func=float):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrange',
+                super(OcRedis, self).zrange, name, None, name, start, end, desc, withscores, score_cast_func)
+
+    def zrangebylex(self, name, min, max, start=None, num=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrangebylex',
+                super(OcRedis, self).zrangebylex, name, None, name, min, max, start, num)
+
+    def zrangebyscore(self, name, min, max, start=None, num=None, withscores=False, score_cast_func=float):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrangebyscore',
+                super(OcRedis, self).zrangebyscore, name, None, name, min, max, start, num, withscores, score_cast_func)
+
+    def zrank(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrank',
+                super(OcRedis, self).zrank, name, None, name, value)
+
+    def zrem(self, name, *values):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrem',
+                super(OcRedis, self).zrem, name, None, name, *values)
+
+    def zremrangebylex(self, name, min, max):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zremrangebylex',
+                super(OcRedis, self).zremrangebylex, name, None, name, min, max)
+
+    def zremrangebyrank(self, name, min, max):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zremrangebyrank',
+                super(OcRedis, self).zremrangebyrank, name, None, name, min, max)
+
+    def zremrangebyscore(self, name, min, max):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zremrangebyscore',
+                super(OcRedis, self).zremrangebyscore, name, None, name, min, max)
+
+    def zrevrange(self, name, start, end, withscores=False, score_cast_func=float):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrevrange',
+                super(OcRedis, self).zrevrange, name, None, name, start, end, withscores, score_cast_func)
+
+    def zrevrangebylex(self, name, max, min, start=None, num=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrevrangebylex',
+                super(OcRedis, self).zrevrangebylex, name, None, name, max, min, start, num)
+
+    def zrevrangebyscore(self, name, start, end, withscores=False, score_cast_func=float):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrevrangebyscore',
+                super(OcRedis, self).zrevrangebyscore, name, None, name, start, end, withscores, score_cast_func)
+
+    def zrevrank(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zrevrank',
+                super(OcRedis, self).zrevrank, name, value, name, value)
+
+    def zscan(self, name, cursor=0, match=None, count=None, score_cast_func=float):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zscan',
+                super(OcRedis, self).zscan, name, cursor, match, count, score_cast_func)
+
+    def zscan_iter(self, name, match=None, count=None, score_cast_func=float):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zscan_iter',
+                super(OcRedis, self).zscan_iter, name, None, name, match, count, score_cast_func)
+
+    def zscore(self, name, value):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zscore',
+                super(OcRedis, self).zscore, name, value, name, value)
+
+    def zunionstore(self, dest, keys, aggregate=None):
+        return trace_and_record_stats_with_key_and_value(
+                'redispy.Redis.zunionstore',
+                super(OcRedis, self).zunionstore, dest, keys, dest, keys, aggregate)

--- a/ocredis/observability.py
+++ b/ocredis/observability.py
@@ -1,0 +1,178 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from opencensus.trace import execution_context
+from opencensus.trace.status import Status
+from opencensus.trace.tracer import noop_tracer
+
+from opencensus.stats import stats
+from opencensus.stats import aggregation
+from opencensus.stats import measure
+from opencensus.stats import view
+from opencensus.tags import tag_key
+from opencensus.tags import tag_map
+from opencensus.tags import tag_value
+
+key_error = tag_key.TagKey("error")
+key_method = tag_key.TagKey("method")
+key_status = tag_key.TagKey("status")
+
+m_latency_ms = measure.MeasureFloat("redispy/latency", "The latency per call in milliseconds", "ms")
+m_key_length = measure.MeasureInt("redispy/key_length", "The length of each key", "By")
+m_value_length = measure.MeasureInt("redispy/value_length", "The length of each value", "By")
+
+
+def register_views():
+    all_tag_keys = [key_method, key_error, key_status]
+    calls_view = view.View("redispy/calls", "The number of calls",
+            all_tag_keys,
+            m_latency_ms,
+            aggregation.CountAggregation())
+
+    latency_view = view.View("redispy/latency", "The distribution of the latencies per method", 
+            all_tag_keys,
+            m_latency_ms,
+            aggregation.DistributionAggregation([
+            # Latency in buckets:
+            # [
+            #    >=0ms, >=5ms, >=10ms, >=25ms, >=40ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms,
+            #    >=600ms, >=800ms, >=1s, >=2s, >=4s, >=6s, >=10s, >-20s, >=50s, >=100s
+            # ]
+                0, 5, 10, 25, 40, 50, 75, 1e2, 2e2, 4e2,
+                6e2, 8e2, 1e3, 2e3, 4e3, 6e3, 1e4, 2e4, 5e4, 10e5
+            ])
+    )
+  
+    key_lengths_view = view.View("redispy/key_lengths", "The distribution of the key lengths",
+            all_tag_keys,
+            m_key_length,
+            aggregation.DistributionAggregation([
+            # Key length buckets:
+            # [
+            #   0B, 5B, 10B, 20B, 50B, 100B, 200B, 500B, 1000B, 2000B, 5000B
+            # ]
+                0, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000
+            ])
+    )
+
+    value_lengths_view = view.View("redispy/value_lengths", "The distribution of the value lengths",
+            all_tag_keys,
+            m_value_length,
+            aggregation.DistributionAggregation([
+            # Value length buckets:
+            # [
+            #   0B, 5B, 10B, 20B, 50B, 100B, 200B, 500B, 1000B, 2000B, 5000B, 10000B, 20000B
+            # ]
+                0, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000
+            ])
+    )
+    view_manager = stats.Stats().view_manager
+    for each_view in [calls_view, latency_view, key_lengths_view, value_lengths_view]:
+        view_manager.register_view(each_view)
+
+
+## Some extracted types for comparisons inside function "lengths"
+strType = type('')
+tupleType = type((1,2,))
+listType = type([])
+dictType = type(dict())
+
+
+def heuristical_lengths(items):
+    """
+    heuristical_lengths tries to deriver the lengths of the content of items.
+    It always returns a list.
+    a) If typeof(items) is a string, it'll return [len(items)]
+    b) If typeof(items) is a dict, it'll return [len(items)]
+    c) If typeof(items) is either list or tuple, it'll best case try to iterate
+       over each element and record those lengths and return them all flattened.
+       If it can't retrieve the lengths yet len(items) > 0, then it will return [len(items)]
+    d) If items has the '__len__' attribute, it'll return [len(items)]
+    e) Otherwise if it can't derive the type, it'll return []
+    """
+    typ = type(items)
+
+    if isinstance(typ, strType):
+        return [len(items)]
+
+    elif isinstance(typ, dictType):
+        return [len(items)]
+
+    elif isinstance(typ, tupleType) or isinstance(typ, listType):
+        lengths = []
+        for item in items:
+            i_lengths = lengths(item)
+            lengths.extend(i_lengths)
+
+        # In the best case, if len(lengths) == 0
+        # yet len(items) > 0, just use len(items)
+        if len(lengths) == 0 and len(items) > 0:
+            lengths = [len(items)]
+
+        return lengths
+
+    elif hasattr(items, '__len__'):
+        return [len(items)]
+
+    elif hasattr(items, '__iter__'):
+        lengths = []
+        itr = iter(items)
+        for it in itr:
+            it_lengths = heuristical_lengths(it)
+            lengths.extend(it_lengths)
+
+        return lengths
+
+    else:
+       return []
+
+
+def trace_and_record_stats_with_key_and_value(method_name, fn, key, value, *args, **kwargs):
+    __TRACER = execution_context.get_opencensus_tracer() or noop_tracer.NoopTracer()
+    __STATS_RECORDER = stats.Stats().stats_recorder
+
+    start_time = time.time()
+    tags = tag_map.TagMap()
+    tags.insert(key_method, tag_value.TagValue(method_name))
+    mm = __STATS_RECORDER.new_measurement_map()
+
+    with __TRACER.span(name=method_name) as span:
+        try:
+            return fn(*args, **kwargs)
+
+        except Exception as e:
+            span.status = Status.from_exception(e)
+            tags.insert(key_status, "ERROR")
+            tags.insert(key_error, e.__str__())
+            # Re-raise that exception after we've extracted the error.
+            raise e
+
+        else:
+            tags.insert(key_status, "OK")
+
+        finally:
+            latency_ms = (time.time() - start_time) * 1e3
+            mm.measure_float_put(m_latency_ms, latency_ms)
+            key_lengths = heuristical_lengths(key)
+            value_lengths =  heuristical_lengths(value)
+
+            for key_length in key_lengths:
+                mm.measure_int_put(m_key_length, key_length)
+
+            for value_length in value_lengths:
+                mm.measure_int_put(m_value_length, value_length)
+
+            mm.record(tags)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,63 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A setup module for the redis-py wrapper instrumented using OpenCensus"""
+
+import io
+import sys
+from setuptools.command.test import test as TestCommand
+from setuptools import setup, find_packages
+
+install_requires = [
+    'opencensus >= 0.2.0',
+    'redis >= 3.2.0'
+]
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
+
+setup(
+    name='ocredis',
+    version='0.0.1',
+    author='OpenCensus Authors',
+    author_email='census-developers@googlegroups.com',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    description='A wrapper for redis-py, instrumented using OpenCensus for distributed tracing and metrics',
+    include_package_data=True,
+    long_description=open('README.rst').read(),
+    install_requires=install_requires,
+    license='Apache-2.0',
+    packages=find_packages(),
+    namespace_packages=[],
+    url='https://github.com/opencensus-integrations/ocredispy')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest

--- a/tests/test_invoke_each_method.py
+++ b/tests/test_invoke_each_method.py
@@ -1,0 +1,54 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ocredis
+import redis
+
+def test_methods_on_redis_also_exist_on_ocredis():
+    methods = [
+        'append', 'bgrewriteaof', 'bgsave', 'bitcount', 'bitfield', 'bitop', 'bitpos', 'blpop', 'brpop', 'brpoplpush',
+        'bzpopmax', 'bzpopmin', 'client_getname', 'client_id', 'client_kill', 'client_kill_filter', 'client_list',
+        'client_pause', 'client_setname', 'client_unblock', 'cluster', 'config_get', 'config_resetstat', 'config_rewrite',
+        'config_set', 'dbsize', 'debug_object', 'decr', 'decrby', 'delete', 'dump', 'echo', 'eval', 'evalsha', 'execute_command',
+        'exists', 'expire', 'expireat', 'flushall', 'flushdb', 'from_url', 'geoadd', 'geodist', 'geohash', 'geopos', 'georadius',
+        'georadiusbymember', 'get', 'getbit', 'getrange', 'getset', 'hdel', 'hexists', 'hget', 'hgetall', 'hincrby', 'hincrbyfloat',
+        'hkeys', 'hlen', 'hmget', 'hmset', 'hscan', 'hscan_iter', 'hset', 'hsetnx', 'hstrlen', 'hvals', 'incr', 'incrby',
+        'incrbyfloat', 'info', 'keys', 'lastsave', 'lindex', 'linsert', 'llen', 'lock', 'lpop', 'lpush', 'lpushx', 'lrange',
+        'lrem', 'lset', 'ltrim', 'memory_purge', 'memory_usage', 'mget', 'migrate', 'move', 'mset', 'msetnx', 'object',
+        'parse_response', 'persist', 'pexpire', 'pexpireat', 'pfadd', 'pfcount', 'pfmerge', 'ping', 'pipeline', 'psetex', 'pttl',
+        'publish', 'pubsub', 'pubsub_channels', 'pubsub_numpat', 'pubsub_numsub', 'randomkey', 'register_script',
+        'rename', 'renamenx', 'restore', 'rpop', 'rpoplpush', 'rpush', 'rpushx', 'sadd', 'save', 'scan', 'scan_iter', 'scard',
+        'script_exists', 'script_flush', 'script_kill', 'script_load', 'sdiff', 'sdiffstore', 'sentinel',
+        'sentinel_get_master_addr_by_name', 'sentinel_master', 'sentinel_masters', 'sentinel_monitor', 'sentinel_remove',
+        'sentinel_sentinels', 'sentinel_set', 'sentinel_slaves', 'set', 'set_response_callback', 'setbit', 'setex', 'setnx',
+        'setrange', 'shutdown', 'sinter', 'sinterstore', 'sismember', 'slaveof', 'slowlog_get', 'slowlog_len', 'slowlog_reset',
+        'smembers', 'smove', 'sort', 'spop', 'srandmember', 'srem', 'sscan', 'sscan_iter', 'strlen', 'substr', 'sunion',
+        'sunionstore', 'swapdb', 'time', 'touch', 'transaction', 'ttl', 'type', 'unlink', 'unwatch', 'wait', 'watch', 'xack',
+        'xadd', 'xclaim', 'xdel', 'xgroup_create', 'xgroup_delconsumer', 'xgroup_destroy', 'xgroup_setid', 'xinfo_consumers',
+        'xinfo_groups', 'xinfo_stream', 'xlen', 'xpending', 'xpending_range', 'xrange', 'xread', 'xreadgroup', 'xrevrange',
+        'xtrim', 'zadd', 'zcard', 'zcount', 'zincrby', 'zinterstore', 'zlexcount', 'zpopmax', 'zpopmin', 'zrange', 'zrangebylex',
+        'zrangebyscore', 'zrank', 'zrem', 'zremrangebylex', 'zremrangebyrank', 'zremrangebyscore', 'zrevrange', 'zrevrangebylex',
+        'zrevrangebyscore', 'zrevrank', 'zscan', 'zscan_iter', 'zscore', 'zunionstore']
+
+    for method_name in methods:
+        method_object = getattr(ocredis.OcRedis, method_name)
+        assert method_object != None
+        assert hasattr(method_object, '__call__')
+
+    # Now for the rigorous check.
+    redis_client_namespace_variables = dir(redis.Redis)
+    for redis_client_namespace_variable in redis_client_namespace_variables:
+        ocredis_attr = getattr(ocredis.OcRedis, redis_client_namespace_variable)
+        print(redis_client_namespace_variable)
+        assert ocredis_attr != None

--- a/tests/test_propagate_exceptions.py
+++ b/tests/test_propagate_exceptions.py
@@ -1,0 +1,155 @@
+# Copyright 2019, OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from opencensus.trace import execution_context
+from opencensus.trace.samplers import always_on
+from opencensus.trace.tracer import Tracer
+from opencensus.stats import stats
+from opencensus.stats.aggregation import CountAggregation, DistributionAggregation
+
+import ocredis
+
+class RetainerTraceExporter(object):
+    def __init__(self):
+        self.__spans = []
+
+    def export(self, span_data_list):
+        self.__spans.extend(span_data_list)
+
+    def emit(self, span_data_list):
+        self.__spans.extend(span_data_list)
+
+    def spans(self):
+        return self.__spans
+
+
+class RetainerStatsExporter(object):
+    def __init__(self):
+        self.__view_data = []
+        self.__views     = []
+
+    def export(self, view_data_list):
+        self.__view_data.extend(view_data_list)
+
+    def on_register_view(self, view):
+        self.__views.append(view)
+
+    def view_data(self):
+        return self.__view_data
+
+
+def test_ensure_exceptions_are_raised_yet_reported():
+    span_retainer = RetainerTraceExporter()
+    tracer = Tracer(sampler=always_on.AlwaysOnSampler(), exporter=span_retainer)
+    execution_context.set_opencensus_tracer(tracer)
+
+    view_data_retainer = RetainerStatsExporter()
+    view_manager = stats.Stats().view_manager
+    view_manager.register_exporter(view_data_retainer)
+    ocredis.register_views()
+
+    with pytest.raises(Exception):
+        invalid_port = 1<<18
+        client = ocredis.OcRedis(host='localhost', port=invalid_port)
+        client.get('newer')
+
+    spans = span_retainer.spans()
+    assert len(spans) == 2
+
+    span0 = spans[0]
+    span1 = spans[1]
+    assert span0.name == 'redispy.Redis.execute_command'
+    assert span1.name == 'redispy.Redis.get'
+
+    # Ensure that the span for .get is the root span.
+    assert span1.parent_span_id == None
+    assert span0.parent_span_id == span1.span_id
+
+    # Now check that the top most span has a Status
+    root_span_status = span1.status
+    assert root_span_status.code == 2 # Unknown as per https://opencensus.io/tracing/span/status/#status-code-mapping
+    assert root_span_status.message == 'Error 8 connecting to localhost:262144. nodename nor servname provided, or not known.'
+    assert root_span_status.details == None
+
+    # Also ensure that the child span got the erraneous status recorded.
+    child_span_status = span0.status
+    assert child_span_status.code == 2 # Unknown as per https://opencensus.io/tracing/span/status/#status-code-mapping
+    assert child_span_status.message == 'Error 8 connecting to localhost:262144. nodename nor servname provided, or not known.'
+    assert child_span_status.details == None
+
+    # Next let's check that stats are recorded.
+    view_data_list = view_data_retainer.view_data()
+    assert len(view_data_list) >= 2
+
+    # Expecting the values for the various views per method.
+    # However, since stats recording is time-imprecise we can
+    # less or more values recorded, hence bucketize view_data by
+    # name first and then perform the various assertions.
+    view_data_by_name = bucketize_view_data_by_name(view_data_list)
+
+    calls_view_data_list = view_data_by_name['redispy/calls']
+    assert len(calls_view_data_list) > 0
+
+    latency_view_data_list = view_data_by_name['redispy/latency']
+    assert len(latency_view_data_list) > 0
+
+    calls_view_data_execute_command = calls_view_data_list[0]
+    latency_view_data_execute_command = latency_view_data_list[0]
+
+    count_aggregation = CountAggregation()
+    view_calls_execute_command = calls_view_data_execute_command.view
+    assert view_calls_execute_command.aggregation.aggregation_type == count_aggregation.aggregation_type
+    # assert view_calls_execute_command.aggregation.count == 1
+    assert view_calls_execute_command.name == "redispy/calls"
+    assert view_calls_execute_command.description == "The number of calls"
+    assert view_calls_execute_command.columns == ['method', 'error', 'status']
+    # calls_execute_command_tag_values = view_calls_execute_command.get_tag_values(
+    #                    calls_view_data_execute_command.columns,  view_calls_execute_command.columns)
+
+    calls_tag_values = calls_view_data_execute_command.tag_value_aggregation_data_map.keys()
+    sorted_calls_tag_values = sorted(calls_tag_values, key=lambda tag_value_tuple: tag_value_tuple[0])
+    print('calls_tags_values', sorted_calls_tag_values)
+    assert len(sorted_calls_tag_values) >= 2
+    assert sorted_calls_tag_values[0] == (
+                'redispy.Redis.execute_command',
+                'Error 8 connecting to localhost:262144. nodename nor servname provided, or not known.',
+                'ERROR',
+            )
+    
+
+    latency_distribution_aggregation = DistributionAggregation()
+    view_latency_execute_command = latency_view_data_execute_command.view
+    assert view_latency_execute_command.aggregation.aggregation_type == latency_distribution_aggregation.aggregation_type
+    # assert view_calls_execute_command.aggregation.count == 1
+    assert view_latency_execute_command.name == "redispy/latency"
+    assert view_latency_execute_command.description == "The distribution of the latencies per method"
+    assert view_latency_execute_command.columns == ['method', 'error', 'status']
+    # calls_execute_command_tag_values = view_calls_execute_command.get_tag_values(
+    #                    calls_view_data_execute_command.columns,  view_calls_execute_command.columns)
+
+    # TODO: File a bug with OpenCensus-Python about them using strings
+    # for start and endtime, instead of actual date* objects on which we
+    # can easily calculate time spent etc.
+    assert latency_view_data_execute_command.start_time != ''
+    assert latency_view_data_execute_command.end_time != ''
+    # latency_ms = latency_view_data_execute_command.end_time - latency_view_data_execute_command.start_time
+    # assert latency_ms > 0.0
+
+def bucketize_view_data_by_name(view_data_list):
+    by_name_buckets = {}
+    for view_data in view_data_list:
+        by_name_buckets.setdefault(view_data.view.name, []).append(view_data)
+    return by_name_buckets


### PR DESCRIPTION
OcRedis is a full drop-in replacement for redis.Redis.
It wraps redis.Redis and uses OpenCensus to collect
traces and metrics for each invocation.
It captures and counts errors, method invocations and delivers
them as traces as well as views that are then exported as metrics.

Sample usage:
```python
import ocredis

def main():
   client = ocredis.OcRedis(host='localhost')

   # Turn on stats collection and reporting.
   # Please remember to then use any of the OpenCensus exporters
   # defined at https://opencensus.io/exporters/supported-exporters/python/
   ocredis.register_views()
   # Enable your exporter of choice here.

   # Now use the client normally just like you would use redis.Redis
   value = client.get('name_here')
   client.del('name_here')
```